### PR TITLE
remove explicit reference to property column in predict.binned_factor

### DIFF
--- a/R/bin_factor.R
+++ b/R/bin_factor.R
@@ -79,7 +79,7 @@ predict.binned_factor <- function(binned_feature, dframe){
 
   dframe[[feature]] <- factor(dframe[[feature]])
 
-  dframe$node <- predict(binned_feature$tree, newdata = dframe[,"property"], type = 'node')
+  dframe$node <- predict(binned_feature$tree, newdata = dframe %>% select(!!feature), type = 'node')
   dframe$node <- if_else(is.na(dframe[[feature]]), NA_integer_, dframe$node)
 
   dframe %<>%

--- a/tests/testthat/test_bin_factor.R
+++ b/tests/testthat/test_bin_factor.R
@@ -69,10 +69,20 @@ test_that("binned_factor objects have a predict method, if supervised binning wa
   binned_feature <- bin_factor(german_credit_data, x = feature_to_bin, supervised = TRUE)
 
   data_with_binned_feature <- predict(binned_feature, german_credit_data)
-  expected_factor_levels <- c("real estate", "car or other; svngs. agrrement", "unknown/no")
+  binned_levels <- binned_feature$levels
 
 
-  expect_true(all(data_with_binned_feature[[feature_to_bin]] %in% expected_factor_levels))
+  expect_true(all(data_with_binned_feature[[feature_to_bin]] %in% binned_levels))
+})
+
+test_that("the binned_factor predict method works with features other than property", {
+  feature_to_bin <- "ca_status"
+  binned_feature <- bin_factor(german_credit_data, x = feature_to_bin, supervised = TRUE)
+
+  data_with_binned_feature <- predict(binned_feature, german_credit_data)
+  binned_levels <- binned_feature$levels
+
+  expect_true(all(data_with_binned_feature[[feature_to_bin]] %in% binned_levels))
 })
 
 test_that("binned_factor objects have a plot method that creates a graph with 3 elements", {


### PR DESCRIPTION
There was a bug in the code whereby `predict.binned_factor` explicitly referenced the `property` column from the german credit data dataset.